### PR TITLE
fix stopPoint.getInRadius

### DIFF
--- a/lib/stopPoint.ts
+++ b/lib/stopPoint.ts
@@ -146,10 +146,10 @@ export default class StopPoint extends TfLAPI {
         returnLines: boolean,
         latitude: number,
         longitude: number
-    ): Promise<Array<TfL['StopPointsResponse']>> {
+    ): Promise<TfL['StopPointsResponse']> {
         return this.sendRequest(
             `/StopPoint`,
-            { stopTypes: TfLAPI.arrayToCSV(stopTypes), radius, useStopPointHierarchy, modes: TfLAPI.arrayToCSV(modes), categories: TfLAPI.arrayToCSV(categories), returnLines, latitude, longitude },
+            { stopTypes: TfLAPI.arrayToCSV(stopTypes), radius, useStopPointHierarchy, modes: TfLAPI.arrayToCSV(modes), categories: TfLAPI.arrayToCSV(categories), returnLines, lat: latitude, lon: longitude },
             'GET'
         );
     }


### PR DESCRIPTION
Changed args "latitude" and "longitude" to send as "lat" and "lon" (TFL changed these at some point)
Removed <Array >: the response Promise contains a TfL['StopPointsResponse'], not an Array of them