### PR TITLE
docs(readme): fix wrong type of 'its'

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ stopPoint.getStationArrivals('940GZZLUKSX').then((arrivals) => {
 ```
 
 ## Disclaimer
-This repository is not affiliated, associated, authorized, endorsed by, or in any way officially connected with Transport for London (TfL) or it's parent organisation Greater London Authority (GLA)
+This repository is not affiliated, associated, authorized, endorsed by, or in any way officially connected with Transport for London (TfL) or its parent organisation Greater London Authority (GLA)


### PR DESCRIPTION
Sorry this is a really pedantic, pathetic single character commit but I figured I'd fix it while I'm here. I'll likely be using the library soon, so I'll try and make up for this in the form of an actual contribution.